### PR TITLE
Observability + Anonymous Feedback (Firestore + reCAPTCHA); Localized Settings page

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -103,6 +103,10 @@ warn_unused_ignores = true
 module = ["crawl4ai", "bs4", "google.adk.*", "google.genai.*"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["google.cloud.firestore", "google.cloud.recaptchaenterprise_v1"]
+ignore_missing_imports = true
+
 # Pytest configuration
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,6 +19,10 @@ dependencies = [
     "numpy>=1.26.0",
     "structlog>=24.4.0",
     "configcat-client>=9.0.4",
+    "google-cloud-logging>=3.11.3",
+    "google-cloud-firestore>=2.16.0",
+    "google-cloud-recaptcha-enterprise>=1.26.2",
+    "httpx>=0.27.2",
 ]
 
 [project.optional-dependencies]

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -17,6 +17,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
+from src.routes.feedback import router as feedback_router
 from src.text.router import router as text_router
 from src.utils.feature_flags.service import create_feature_flag_service
 from src.utils.logging import get_logger, setup_logging
@@ -26,7 +27,6 @@ from src.utils.session_manager import session_manager
 from src.utils.status_router import router as status_router
 from src.voice.router import router as voice_router
 from src.voice.session_manager import voice_session_manager
-from src.routes.feedback import router as feedback_router
 
 warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -26,6 +26,7 @@ from src.utils.session_manager import session_manager
 from src.utils.status_router import router as status_router
 from src.voice.router import router as voice_router
 from src.voice.session_manager import voice_session_manager
+from src.routes.feedback import router as feedback_router
 
 warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")
 
@@ -145,6 +146,7 @@ app.include_router(text_router)
 app.include_router(voice_router)
 app.include_router(metrics_router)
 app.include_router(status_router)
+app.include_router(feedback_router)
 
 STATIC_DIR = Path("static")
 # Only mount static files if the directory exists

--- a/backend/src/routes/__init__.py
+++ b/backend/src/routes/__init__.py
@@ -1,3 +1,1 @@
 """Routes package."""
-
-

--- a/backend/src/routes/__init__.py
+++ b/backend/src/routes/__init__.py
@@ -1,0 +1,3 @@
+"""Routes package."""
+
+

--- a/backend/src/routes/feedback.py
+++ b/backend/src/routes/feedback.py
@@ -1,0 +1,47 @@
+from fastapi import APIRouter, HTTPException, Header
+from pydantic import BaseModel, Field
+from google.cloud import firestore
+
+from src.utils.logging import get_logger
+from .recaptcha_util import verify_recaptcha
+
+
+router = APIRouter(prefix="/api")
+db = firestore.Client()
+logger = get_logger(__name__)
+
+ALLOWED_REASONS = {"too_fast", "too_slow", "confusing", "not_relevant"}
+
+
+class FeedbackIn(BaseModel):
+    helpful: bool
+    reasons: list[str] = Field(default_factory=list)
+    session_id: str | None = None
+    lang: str | None = None
+    platform: str | None = None
+    recaptcha_token: str
+    recaptcha_action: str = "submit_feedback"
+
+
+@router.post("/feedback")
+async def post_feedback(
+    body: FeedbackIn, x_observability_opt_in: str | None = Header(default=None)
+):
+    score = verify_recaptcha(token=body.recaptcha_token, action=body.recaptcha_action)
+    if score < 0.5:
+        raise HTTPException(status_code=400, detail="recaptcha_low_score")
+
+    doc = {
+        "helpful": body.helpful,
+        "reasons": [r for r in body.reasons if r in ALLOWED_REASONS],
+        "session_id": (body.session_id or "none")[:64],
+        "lang": body.lang or "unknown",
+        "platform": body.platform or "unknown",
+        "opt_in_observability": x_observability_opt_in == "1",
+    }
+
+    db.collection("feedback_v1").add(doc)
+    logger.info("feedback_received", **doc)
+    return {"ok": True}
+
+

--- a/backend/src/routes/feedback.py
+++ b/backend/src/routes/feedback.py
@@ -1,7 +1,7 @@
 import os
 
 from fastapi import APIRouter, Header, HTTPException
-from google.cloud import firestore
+from google.cloud import firestore  # type: ignore[attr-defined]
 from pydantic import BaseModel, Field
 
 from src.utils.logging import get_logger

--- a/backend/src/routes/feedback.py
+++ b/backend/src/routes/feedback.py
@@ -1,23 +1,22 @@
 import os
-from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Header
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, Header, HTTPException
 from google.cloud import firestore
+from pydantic import BaseModel, Field
 
 from src.utils.logging import get_logger
-from .recaptcha_util import verify_recaptcha
 
+from .recaptcha_util import verify_recaptcha
 
 router = APIRouter(prefix="/api")
 logger = get_logger(__name__)
 
 ALLOWED_REASONS = {"too_fast", "too_slow", "confusing", "not_relevant"}
 
-_db_client: Optional[firestore.Client] = None
+_db_client: firestore.Client | None = None
 
 
-def get_db_client() -> Optional[firestore.Client]:
+def get_db_client() -> firestore.Client | None:
     global _db_client
     if _db_client is not None:
         return _db_client

--- a/backend/src/routes/recaptcha_util.py
+++ b/backend/src/routes/recaptcha_util.py
@@ -1,0 +1,52 @@
+import os
+from typing import Optional
+
+import httpx
+from google.cloud import recaptchaenterprise_v1 as recaptcha
+
+
+PROVIDER = os.environ.get("RECAPTCHA_PROVIDER", "enterprise").lower()
+PROJECT = os.environ.get("GOOGLE_CLOUD_PROJECT", "")
+SITE_KEY = os.environ.get("RECAPTCHA_SITE_KEY", "")  # Enterprise site key ID
+SECRET = os.environ.get("RECAPTCHA_SECRET", "")  # Classic v3/v2 secret (if used)
+
+
+def verify_recaptcha(token: str, action: str = "submit_feedback") -> float:
+    """Validate a reCAPTCHA token and return a risk score in [0,1].
+
+    - Enterprise path uses ADC (no server secret) and validates action.
+    - Classic path (v3/v2) posts to siteverify using SECRET; returns score (v3) or 0.9 if success (v2).
+    """
+    if PROVIDER == "enterprise":
+        if not (PROJECT and SITE_KEY):
+            return 0.0
+        client = recaptcha.RecaptchaEnterpriseServiceClient()
+        parent = f"projects/{PROJECT}"
+        event = recaptcha.Event(token=token, site_key=SITE_KEY)
+        req = recaptcha.CreateAssessmentRequest(
+            parent=parent, assessment=recaptcha.Assessment(event=event)
+        )
+        resp = client.create_assessment(request=req)
+        if not (
+            resp.token_properties.valid
+            and (resp.token_properties.action or action) == action
+        ):
+            return 0.0
+        return float(resp.risk_analysis.score or 0.0)
+
+    # Classic path
+    if not (SECRET and token):
+        return 0.0
+    r = httpx.post(
+        "https://www.google.com/recaptcha/api/siteverify",
+        data={"secret": SECRET, "response": token},
+        timeout=10,
+    )
+    data = r.json()
+    if not data.get("success"):
+        return 0.0
+    if "action" in data and data.get("action") != action:
+        return 0.0
+    return float(data.get("score", 0.9))
+
+

--- a/backend/src/routes/recaptcha_util.py
+++ b/backend/src/routes/recaptcha_util.py
@@ -1,9 +1,7 @@
 import os
-from typing import Optional
 
 import httpx
 from google.cloud import recaptchaenterprise_v1 as recaptcha
-
 
 PROVIDER = os.environ.get("RECAPTCHA_PROVIDER", "enterprise").lower()
 PROJECT = os.environ.get("GOOGLE_CLOUD_PROJECT", "")
@@ -48,5 +46,3 @@ def verify_recaptcha(token: str, action: str = "submit_feedback") -> float:
     if "action" in data and data.get("action") != action:
         return 0.0
     return float(data.get("score", 0.9))
-
-

--- a/frontend/app/[locale]/settings/page.tsx
+++ b/frontend/app/[locale]/settings/page.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react'
 import { AppLayout } from '@/components/layout/AppLayout'
 import { GlassCard } from '@/components/layout/GlassCard'
 import { executeRecaptcha } from '@/lib/recaptcha'
-import { getTranslations } from 'next-intl/server'
 
 export default function SettingsPage({ params }: { params: { locale: string } }) {
   const [optIn, setOptIn] = useState(false)

--- a/frontend/app/[locale]/settings/page.tsx
+++ b/frontend/app/[locale]/settings/page.tsx
@@ -1,0 +1,111 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { AppLayout } from '@/components/layout/AppLayout'
+import { GlassCard } from '@/components/layout/GlassCard'
+import { executeRecaptcha } from '@/lib/recaptcha'
+import { getTranslations } from 'next-intl/server'
+
+export default function SettingsPage({ params }: { params: { locale: string } }) {
+  const [optIn, setOptIn] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [msg, setMsg] = useState<string | null>(null)
+  const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY!
+
+  useEffect(() => {
+    const v = localStorage.getItem('telemetry_opt_in')
+    setOptIn(v === 'true')
+  }, [])
+
+  function saveOptIn(v: boolean) {
+    setOptIn(v)
+    localStorage.setItem('telemetry_opt_in', v ? 'true' : 'false')
+  }
+
+  async function sendFeedback(helpful: boolean) {
+    try {
+      setSubmitting(true); setMsg(null)
+      const token = await executeRecaptcha('submit_feedback', siteKey)
+      const res = await fetch('/api/feedback', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(optIn ? { 'X-Observability-Opt-In': '1' } : {}),
+        },
+        body: JSON.stringify({
+          helpful,
+          reasons: [],
+          session_id: crypto.getRandomValues(new Uint32Array(1))[0].toString(16),
+          lang: params.locale,
+          platform: 'web',
+          recaptcha_token: token,
+          recaptcha_action: 'submit_feedback',
+        })
+      })
+      if (!res.ok) throw new Error(await res.text())
+      setMsg('Thanks for the feedback!')
+    } catch (e) {
+      setMsg('Could not submit feedback. Please try later.')
+    } finally { setSubmitting(false) }
+  }
+
+  const t = (key: string) => {
+    const dict: Record<string, Record<string, string>> = {
+      en: {
+        settings: 'Settings',
+        helpUs: 'Help us improve anonymously',
+        helpUsDesc: 'We measure anonymous technical signals (timing, error rates). No message content is stored.',
+        toggle: 'Enable anonymous telemetry',
+        quickFeedback: 'Quick feedback',
+        yes: 'Yes',
+        no: 'Not really',
+        thanks: 'Thanks for the feedback!',
+        failed: 'Could not submit feedback. Please try later.'
+      },
+      es: {
+        settings: 'Ajustes',
+        helpUs: 'Ayúdanos a mejorar de forma anónima',
+        helpUsDesc: 'Medimos señales técnicas anónimas (tiempos, errores). No se guarda contenido de mensajes.',
+        toggle: 'Activar telemetría anónima',
+        quickFeedback: 'Opinión rápida',
+        yes: 'Sí',
+        no: 'No mucho',
+        thanks: '¡Gracias por tu opinión!',
+        failed: 'No se pudo enviar la opinión. Inténtalo más tarde.'
+      }
+    }
+    return (dict[params.locale as 'en' | 'es'] || dict.en)[key]
+  }
+
+  return (
+    <AppLayout
+      locale={params.locale}
+      showBackButton
+      currentLanguage={params.locale === 'es' ? 'ES' : 'EN'}
+      onLanguageChange={() => {}}
+    >
+      <main className="max-w-2xl mx-auto p-6 space-y-6">
+        <h1 className="text-2xl font-semibold text-white">{t('settings')}</h1>
+
+        <GlassCard className="p-4">
+          <h2 className="text-lg font-medium text-white mb-2">{t('helpUs')}</h2>
+          <p className="text-sm text-white/70 mb-3">{t('helpUsDesc')}</p>
+          <label className="inline-flex items-center gap-3 text-white">
+            <input type="checkbox" checked={optIn} onChange={(e) => saveOptIn(e.target.checked)} />
+            <span>{t('toggle')}</span>
+          </label>
+        </GlassCard>
+
+        <GlassCard className="p-4">
+          <h2 className="text-lg font-medium text-white mb-2">{t('quickFeedback')}</h2>
+          <div className="flex gap-3">
+            <button className="px-3 py-2 rounded bg-white/10 text-white" disabled={submitting} onClick={() => sendFeedback(true)}>{t('yes')}</button>
+            <button className="px-3 py-2 rounded bg-white/10 text-white" disabled={submitting} onClick={() => sendFeedback(false)}>{t('no')}</button>
+          </div>
+          {msg && <p className="mt-3 text-sm text-white/80">{msg}</p>}
+        </GlassCard>
+      </main>
+    </AppLayout>
+  )
+}
+
+

--- a/frontend/lib/recaptcha.ts
+++ b/frontend/lib/recaptcha.ts
@@ -1,0 +1,16 @@
+export async function executeRecaptcha(action: string, siteKey: string): Promise<string> {
+  await new Promise<void>((resolve) => {
+    const w = window as any
+    if (w.grecaptcha?.enterprise) return resolve()
+    const s = document.createElement('script')
+    s.src = 'https://www.google.com/recaptcha/enterprise.js?render=' + siteKey
+    s.async = true
+    s.defer = true
+    s.onload = () => resolve()
+    document.head.appendChild(s)
+  })
+  const w = window as any
+  return await w.grecaptcha.enterprise.execute(siteKey, { action })
+}
+
+

--- a/frontend/lib/recaptcha.ts
+++ b/frontend/lib/recaptcha.ts
@@ -1,6 +1,19 @@
 export async function executeRecaptcha(action: string, siteKey: string): Promise<string> {
+  const provider = (process.env.NEXT_PUBLIC_RECAPTCHA_PROVIDER || 'enterprise').toLowerCase()
+
   await new Promise<void>((resolve) => {
     const w = window as any
+    if (provider === 'classic') {
+      if (w.grecaptcha) return resolve()
+      const s = document.createElement('script')
+      s.src = 'https://www.google.com/recaptcha/api.js?render=' + siteKey
+      s.async = true
+      s.defer = true
+      s.onload = () => resolve()
+      document.head.appendChild(s)
+      return
+    }
+    // enterprise
     if (w.grecaptcha?.enterprise) return resolve()
     const s = document.createElement('script')
     s.src = 'https://www.google.com/recaptcha/enterprise.js?render=' + siteKey
@@ -9,7 +22,11 @@ export async function executeRecaptcha(action: string, siteKey: string): Promise
     s.onload = () => resolve()
     document.head.appendChild(s)
   })
+
   const w = window as any
+  if (provider === 'classic') {
+    return await w.grecaptcha.execute(siteKey, { action })
+  }
   return await w.grecaptcha.enterprise.execute(siteKey, { action })
 }
 


### PR DESCRIPTION
This PR implements plan.md items with i18n preserved.\n\nBackend\n- Add /api/feedback endpoint storing documents in Firestore (collection feedback_v1)\n- reCAPTCHA verification: Enterprise by default (ADC), Classic v3/v2 fallback via SECRET\n- Wire routes into FastAPI app\n- Add deps: google-cloud-firestore, google-cloud-recaptcha-enterprise, httpx, google-cloud-logging (for future structured logs)\n\nFrontend\n- New localized Settings page at /[locale]/settings with telemetry toggle and quick feedback\n- reCAPTCHA enterprise helper (script loader + execute)\n- Uses existing i18n pattern (per-locale pages; copy kept minimal)\n\nConfig\n- Env: NEXT_PUBLIC_RECAPTCHA_SITE_KEY at build time; backend needs RECAPTCHA_PROVIDER (enterprise|classic), GOOGLE_CLOUD_PROJECT, RECAPTCHA_SITE_KEY (enterprise) or RECAPTCHA_SECRET (classic)\n\nFollow-up\n- Optionally add structured Cloud Logging helper per plan.md and expand translations in locales JSON if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized settings page allowing users to opt in or out of anonymous telemetry.
  * Introduced a feedback form with reCAPTCHA v3 protection, supporting English and Spanish.
  * Feedback submissions now include telemetry opt-in status and are securely validated and stored.
  * Implemented reCAPTCHA token verification with support for both enterprise and classic providers.
  * Added dynamic loading of reCAPTCHA scripts on the frontend based on provider configuration.

* **Chores**
  * Updated backend dependencies to support Google Cloud services and HTTP requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->