### PR TITLE
Frontend proxy stability + reCAPTCHA hardening

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -215,6 +215,17 @@ jobs:
 
       - name: Deploy frontend
         run: |
+          # Compute stable proxy envs with overrides
+          BACKEND_URL="${{ needs.deploy-backend.outputs.backend_url }}"
+          PUBLIC_OVERRIDE="${{ secrets.FRONTEND_BACKEND_PUBLIC_URL }}"
+          INTERNAL_OVERRIDE="${{ secrets.FRONTEND_BACKEND_INTERNAL_HOST }}"
+          AUDIENCE_URL=${PUBLIC_OVERRIDE:-$BACKEND_URL}
+          INTERNAL_HOST=${INTERNAL_OVERRIDE:-"${{ env.BACKEND_SERVICE }}.${{ env.REGION }}.internal"}
+
+          # Pass NEXT_PUBLIC_* if provided (build-time for Next.js; kept here for SSR/runtime parity)
+          NP_SITE_KEY="${{ secrets.NEXT_PUBLIC_RECAPTCHA_SITE_KEY }}"
+          NP_PROVIDER="${{ secrets.NEXT_PUBLIC_RECAPTCHA_PROVIDER }}"
+
           gcloud run deploy ${{ env.FRONTEND_SERVICE }} \
             --image          ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${{ needs.gate.outputs.head_sha }} \
             --platform       managed \
@@ -229,7 +240,7 @@ jobs:
             --memory         1Gi \
             --min-instances  0 \
             --max-instances  10 \
-            --set-env-vars   "NODE_ENV=production,BACKEND_INTERNAL_HOST=${{ env.BACKEND_SERVICE }}.${{ env.REGION }}.internal,BACKEND_PUBLIC_URL=${{ needs.deploy-backend.outputs.backend_url }},GCP_PROJECT_ID=${{ env.PROJECT_ID }},GCP_REGION=${{ env.REGION }}"
+            --set-env-vars   "NODE_ENV=production,GCP_PROJECT_ID=${{ env.PROJECT_ID }},GCP_REGION=${{ env.REGION }},BACKEND_INTERNAL_HOST=${INTERNAL_HOST},BACKEND_PUBLIC_URL=${AUDIENCE_URL}${NP_SITE_KEY:+,NEXT_PUBLIC_RECAPTCHA_SITE_KEY=$NP_SITE_KEY}${NP_PROVIDER:+,NEXT_PUBLIC_RECAPTCHA_PROVIDER=$NP_PROVIDER}"
 
       - name: Grant frontend SA invoke rights on backend
         run: |

--- a/backend/src/routes/feedback.py
+++ b/backend/src/routes/feedback.py
@@ -1,9 +1,9 @@
 import os
 
 from fastapi import APIRouter, Header, HTTPException
+from fastapi.concurrency import run_in_threadpool
 from google.cloud import firestore  # type: ignore[attr-defined]
 from pydantic import BaseModel, Field
-from fastapi.concurrency import run_in_threadpool
 
 from src.utils.logging import get_logger
 
@@ -48,9 +48,9 @@ async def post_feedback(
         score = await run_in_threadpool(
             verify_recaptcha, body.recaptcha_token, body.recaptcha_action
         )
-    except Exception:
+    except Exception as err:
         # Treat provider/network/auth outages as temporary service issues
-        raise HTTPException(status_code=503, detail="recaptcha_unavailable")
+        raise HTTPException(status_code=503, detail="recaptcha_unavailable") from err
     if score < 0.5:
         raise HTTPException(status_code=400, detail="recaptcha_low_score")
 

--- a/backend/src/routes/feedback.py
+++ b/backend/src/routes/feedback.py
@@ -3,6 +3,7 @@ import os
 from fastapi import APIRouter, Header, HTTPException
 from google.cloud import firestore  # type: ignore[attr-defined]
 from pydantic import BaseModel, Field
+from fastapi.concurrency import run_in_threadpool
 
 from src.utils.logging import get_logger
 
@@ -43,7 +44,13 @@ class FeedbackIn(BaseModel):
 async def post_feedback(
     body: FeedbackIn, x_observability_opt_in: str | None = Header(default=None)
 ):
-    score = verify_recaptcha(token=body.recaptcha_token, action=body.recaptcha_action)
+    try:
+        score = await run_in_threadpool(
+            verify_recaptcha, body.recaptcha_token, body.recaptcha_action
+        )
+    except Exception:
+        # Treat provider/network/auth outages as temporary service issues
+        raise HTTPException(status_code=503, detail="recaptcha_unavailable")
     if score < 0.5:
         raise HTTPException(status_code=400, detail="recaptcha_low_score")
 

--- a/frontend/app/[locale]/feedback/page.tsx
+++ b/frontend/app/[locale]/feedback/page.tsx
@@ -1,0 +1,106 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { AppLayout } from '@/components/layout/AppLayout'
+import { GlassCard } from '@/components/layout/GlassCard'
+import { executeRecaptcha } from '@/lib/recaptcha'
+
+export default function FeedbackPage({ params }: { params: { locale: string } }) {
+  const [optIn, setOptIn] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [msg, setMsg] = useState<string | null>(null)
+  const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY!
+
+  useEffect(() => {
+    const v = localStorage.getItem('telemetry_opt_in')
+    setOptIn(v === 'true')
+  }, [])
+
+  function saveOptIn(v: boolean) {
+    setOptIn(v)
+    localStorage.setItem('telemetry_opt_in', v ? 'true' : 'false')
+  }
+
+  async function sendFeedback(helpful: boolean) {
+    try {
+      setSubmitting(true); setMsg(null)
+      const token = await executeRecaptcha('submit_feedback', siteKey)
+      const res = await fetch('/api/feedback', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(optIn ? { 'X-Observability-Opt-In': '1' } : {}),
+        },
+        body: JSON.stringify({
+          helpful,
+          reasons: [],
+          session_id: crypto.getRandomValues(new Uint32Array(1))[0].toString(16),
+          lang: params.locale,
+          platform: 'web',
+          recaptcha_token: token,
+          recaptcha_action: 'submit_feedback',
+        })
+      })
+      if (!res.ok) throw new Error(await res.text())
+      setMsg(params.locale === 'es' ? '¡Gracias por tu opinión!' : 'Thanks for the feedback!')
+    } catch (e) {
+      setMsg(params.locale === 'es' ? 'No se pudo enviar la opinión. Inténtalo más tarde.' : 'Could not submit feedback. Please try later.')
+    } finally { setSubmitting(false) }
+  }
+
+  const t = (key: string) => {
+    const dict: Record<string, Record<string, string>> = {
+      en: {
+        title: 'Feedback',
+        helpUs: 'Help us improve anonymously',
+        helpUsDesc: 'We measure anonymous technical signals (timing, error rates). No message content is stored.',
+        toggle: 'Enable anonymous telemetry',
+        quickFeedback: 'Quick feedback',
+        yes: 'Yes',
+        no: 'Not really',
+      },
+      es: {
+        title: 'Opinión',
+        helpUs: 'Ayúdanos a mejorar de forma anónima',
+        helpUsDesc: 'Medimos señales técnicas anónimas (tiempos, errores). No se guarda contenido de mensajes.',
+        toggle: 'Activar telemetría anónima',
+        quickFeedback: 'Opinión rápida',
+        yes: 'Sí',
+        no: 'No mucho',
+      }
+    }
+    return (dict[params.locale as 'en' | 'es'] || dict.en)[key]
+  }
+
+  return (
+    <AppLayout
+      locale={params.locale}
+      showBackButton
+      currentLanguage={params.locale === 'es' ? 'ES' : 'EN'}
+      onLanguageChange={() => {}}
+    >
+      <main className="max-w-2xl mx-auto p-6 space-y-6">
+        <h1 className="text-2xl font-semibold text-white">{t('title')}</h1>
+
+        <GlassCard className="p-4">
+          <h2 className="text-lg font-medium text-white mb-2">{t('helpUs')}</h2>
+          <p className="text-sm text-white/70 mb-3">{t('helpUsDesc')}</p>
+          <label className="inline-flex items-center gap-3 text-white">
+            <input type="checkbox" checked={optIn} onChange={(e) => saveOptIn(e.target.checked)} />
+            <span>{t('toggle')}</span>
+          </label>
+        </GlassCard>
+
+        <GlassCard className="p-4">
+          <h2 className="text-lg font-medium text-white mb-2">{t('quickFeedback')}</h2>
+          <div className="flex gap-3">
+            <button className="px-3 py-2 rounded bg-white/10 text-white" disabled={submitting} onClick={() => sendFeedback(true)}>{t('yes')}</button>
+            <button className="px-3 py-2 rounded bg-white/10 text-white" disabled={submitting} onClick={() => sendFeedback(false)}>{t('no')}</button>
+          </div>
+          {msg && <p className="mt-3 text-sm text-white/80">{msg}</p>}
+        </GlassCard>
+      </main>
+    </AppLayout>
+  )
+}
+
+

--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -49,6 +49,7 @@ const translations = {
       privacy: 'Privacy',
       support: 'Support',
       about: 'About',
+      feedback: 'Feedback',
       copyright: '© 2025 re-frame.social',
     },
   },
@@ -92,6 +93,7 @@ const translations = {
       privacy: 'Privacidad',
       support: 'Soporte',
       about: 'Acerca de',
+      feedback: 'Opinión',
       copyright: '© 2025 re-frame.social',
     },
   },
@@ -247,6 +249,14 @@ export default function LocalePage({ params }: { params: { locale: string } }) {
                     className="text-white/45 hover:text-[#aefcf5] transition-colors"
                   >
                     {t.footer.about}
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href={`/${params.locale}/feedback`}
+                    className="text-white/45 hover:text-[#aefcf5] transition-colors"
+                  >
+                    {t.footer.feedback}
                   </Link>
                 </li>
               </ul>


### PR DESCRIPTION
This PR stabilizes production proxy envs and hardens reCAPTCHA usage.\n\nCI/CD\n- Deploy workflow always sets proxy envs for frontend:\n  - BACKEND_PUBLIC_URL defaults to backend service URL; override via FRONTEND_BACKEND_PUBLIC_URL secret\n  - BACKEND_INTERNAL_HOST defaults to <backend>.<region>.internal; override via FRONTEND_BACKEND_INTERNAL_HOST secret\n- Optionally includes NEXT_PUBLIC_RECAPTCHA_* from repo secrets\n\nFrontend\n- Proxy route: production fallbacks if envs missing (api.re-frame.social)\n- Robust reCAPTCHA loader: browser guard, provider validation, ready() waits\n- Visible Feedback page at /[locale]/feedback with footer link\n\nBackend\n- Offload reCAPTCHA verification to threadpool; 503 on provider/network outages\n\nOutcome: Eliminates recurring "Backend URL not configured" by setting envs on every deploy; improves resilience and UX.,