### PR TITLE
fix/provide recaptcha creds

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -142,6 +142,8 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-${{ matrix.service }}:${{ github.ref_name }}
           build-args: |
             ${{ matrix.service == 'frontend' && 'BUILD_TARGET=production' || '' }}
+            ${{ matrix.service == 'frontend' && format('NEXT_PUBLIC_RECAPTCHA_SITE_KEY={0}', secrets.NEXT_PUBLIC_RECAPTCHA_SITE_KEY) || '' }}
+            ${{ matrix.service == 'frontend' && format('NEXT_PUBLIC_RECAPTCHA_PROVIDER={0}', secrets.NEXT_PUBLIC_RECAPTCHA_PROVIDER) || '' }}
           cache-from: type=gha
           cache-to:   type=gha,mode=max
 

--- a/frontend/Dockerfile.standalone
+++ b/frontend/Dockerfile.standalone
@@ -84,10 +84,14 @@ RUN echo "Generating TypeScript API client from OpenAPI schema..."; \
 # Build arguments for environment variables
 ARG NEXT_PUBLIC_API_URL
 ARG NEXT_PUBLIC_ENVIRONMENT=production
+ARG NEXT_PUBLIC_RECAPTCHA_SITE_KEY
+ARG NEXT_PUBLIC_RECAPTCHA_PROVIDER
 
 # Set build-time environment variables
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_ENVIRONMENT=$NEXT_PUBLIC_ENVIRONMENT
+ENV NEXT_PUBLIC_RECAPTCHA_SITE_KEY=$NEXT_PUBLIC_RECAPTCHA_SITE_KEY
+ENV NEXT_PUBLIC_RECAPTCHA_PROVIDER=$NEXT_PUBLIC_RECAPTCHA_PROVIDER
 
 # Use Cloud Run specific config if deploying to Cloud Run
 RUN if [ -f "next.config.cloudrun.mjs" ]; then \

--- a/frontend/app/[locale]/chat/chat-client.tsx
+++ b/frontend/app/[locale]/chat/chat-client.tsx
@@ -95,11 +95,13 @@ export function ChatClient({ locale }: { locale: string }) {
         if (ready) {
           await execute('chat_start')
         }
-      } catch {
-        // best effort
+      } catch (err) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.debug('reCAPTCHA chat_start prefetch failed', err)
+        }
       }
     })()
-  }, [ready])
+  }, [ready, execute])
 
   // Handle incoming SSE messages
   useEffect(() => {
@@ -186,7 +188,12 @@ export function ChatClient({ locale }: { locale: string }) {
         if (ready) {
           await execute('chat_message')
         }
-      } catch {}
+      } catch (err) {
+        if (process.env.NODE_ENV !== 'production') {
+          // best-effort prefetch; ignore failures
+          console.debug('reCAPTCHA prefetch failed', err)
+        }
+      }
       await sseClient.sendText(input)
     } catch (error) {
       console.error('Failed to send message:', error)

--- a/frontend/app/[locale]/chat/chat-client.tsx
+++ b/frontend/app/[locale]/chat/chat-client.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { useSSEClient } from '@/lib/streaming/use-sse-client'
 import ReactMarkdown from 'react-markdown'
-import { useEffect as useReactEffect } from 'react'
+// useEffect already imported above
 import { useRecaptcha } from '@/lib/recaptcha/useRecaptcha'
 // Chat screen does not display a language selector; language follows route locale
 
@@ -65,7 +65,8 @@ export function ChatClient({ locale }: { locale: string }) {
   // Prepare reCAPTCHA for chat session
   const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY
   const provider = process.env.NEXT_PUBLIC_RECAPTCHA_PROVIDER === 'enterprise' ? 'enterprise' : 'classic'
-  const { ready, execute } = useRecaptcha(siteKey, provider)
+  const { ready, execute, error } = useRecaptcha(siteKey, provider)
+  useEffect(() => { if (error) console.warn('reCAPTCHA init failed:', error) }, [error])
 
   useEffect(() => {
     setSelectedLanguage(locale === 'es' ? 'es-ES' : 'en-US')
@@ -89,7 +90,7 @@ export function ChatClient({ locale }: { locale: string }) {
   }, [selectedLanguage]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Prefetch a token when chat session starts
-  useReactEffect(() => {
+  useEffect(() => {
     (async () => {
       try {
         if (ready) {
@@ -342,7 +343,7 @@ export function ChatClient({ locale }: { locale: string }) {
             <button
               type="button"
               onClick={handleSendMessage}
-              disabled={isLoading || !input.trim()}
+              disabled={isLoading || !input.trim() || !ready}
               aria-label={t.send}
               className={`w-[56px] h-[56px] flex items-center justify-center rounded-full transition-all disabled:opacity-50 disabled:cursor-not-allowed ${
                 !isLoading && input.trim() ? 'hover:bg-[#7EEBD9] active:bg-[#65D9C6]' : ''

--- a/frontend/app/[locale]/feedback/page.tsx
+++ b/frontend/app/[locale]/feedback/page.tsx
@@ -13,11 +13,10 @@ export default function FeedbackPage({ params }: { params: { locale: string } })
   const [submitting, setSubmitting] = useState(false)
   const [msg, setMsg] = useState<string | null>(null)
   const [comment, setComment] = useState('')
-  const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY!
+  const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY
   const provider = process.env.NEXT_PUBLIC_RECAPTCHA_PROVIDER === 'enterprise' ? 'enterprise' : 'classic'
-  const { ready, execute } = useRecaptcha(siteKey, provider)
-
-  useEffect(() => {}, [])
+  const { ready, execute, error } = useRecaptcha(siteKey, provider)
+  useEffect(() => { if (error) console.warn('reCAPTCHA init failed:', error) }, [error])
 
   async function sendFeedback(helpful: boolean) {
     try {

--- a/frontend/app/[locale]/settings/page.tsx
+++ b/frontend/app/[locale]/settings/page.tsx
@@ -10,9 +10,10 @@ export default function SettingsPage({ params }: { params: { locale: string } })
   const [optIn, setOptIn] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [msg, setMsg] = useState<string | null>(null)
-  const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY!
+  const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY
   const provider = process.env.NEXT_PUBLIC_RECAPTCHA_PROVIDER === 'enterprise' ? 'enterprise' : 'classic'
-  const { ready, execute } = useRecaptcha(siteKey, provider)
+  const { ready, execute, error } = useRecaptcha(siteKey, provider)
+  useEffect(() => { if (error) console.warn('reCAPTCHA init failed:', error) }, [error])
 
   useEffect(() => {
     const v = localStorage.getItem('telemetry_opt_in')

--- a/frontend/app/[locale]/voice/voice-client.tsx
+++ b/frontend/app/[locale]/voice/voice-client.tsx
@@ -50,7 +50,7 @@ export function VoiceClient({ locale }: { locale: string }) {
         // best effort
       }
     })()
-  }, [ready])
+  }, [ready, execute])
 
   const handleBack = () => {
     router.push(`/${locale}`)

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -48,3 +48,9 @@ body {
     box-shadow: 0 0 0 1px rgba(155, 247, 235, 0.25), 0 10px 40px rgba(0, 0, 0, 0.4);
   }
 }
+
+/* Optional: move reCAPTCHA v3 badge to bottom-left while keeping it visible */
+.grecaptcha-badge {
+  left: 12px !important;
+  right: auto !important;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import RecaptchaPreloader from '@/components/RecaptchaPreloader';
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -28,6 +29,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${inter.className} min-h-screen bg-dark-charcoal`}>
+        <RecaptchaPreloader />
         {children}
       </body>
     </html>

--- a/frontend/components/RecaptchaPreloader.tsx
+++ b/frontend/components/RecaptchaPreloader.tsx
@@ -1,0 +1,17 @@
+'use client';
+import { useEffect } from 'react';
+import { useRecaptcha, prefetchToken } from '@/lib/recaptcha/useRecaptcha';
+
+export default function RecaptchaPreloader() {
+  const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
+  const provider = process.env.NEXT_PUBLIC_RECAPTCHA_PROVIDER === 'enterprise' ? 'enterprise' : 'classic';
+  const { ready } = useRecaptcha(siteKey, provider);
+
+  useEffect(() => {
+    if (ready && siteKey) prefetchToken(siteKey, provider, 'preload');
+  }, [ready, siteKey, provider]);
+
+  return null;
+}
+
+

--- a/frontend/lib/recaptcha/useRecaptcha.ts
+++ b/frontend/lib/recaptcha/useRecaptcha.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export type RecaptchaProvider = 'classic' | 'enterprise';
+type W = Window & { grecaptcha?: any };
+
+function loadOnce(src: string, id: string) {
+  return new Promise<void>((resolve, reject) => {
+    if (document.getElementById(id)) return resolve();
+    const s = document.createElement('script');
+    s.id = id;
+    s.async = true;
+    s.defer = true;
+    s.src = src;
+    s.onload = () => resolve();
+    s.onerror = () => reject(new Error('Failed to load reCAPTCHA script'));
+    document.head.appendChild(s);
+  });
+}
+
+export function useRecaptcha(siteKey?: string, provider: RecaptchaProvider = 'classic') {
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const loader = useRef<Promise<void> | null>(null);
+
+  useEffect(() => {
+    if (!siteKey) {
+      setError('Missing reCAPTCHA site key');
+      return;
+    }
+    setError(null);
+
+    if (!loader.current) {
+      const src =
+        provider === 'enterprise'
+          ? `https://www.google.com/recaptcha/enterprise.js?render=${encodeURIComponent(siteKey)}`
+          : `https://www.google.com/recaptcha/api.js?render=${encodeURIComponent(siteKey)}`;
+
+      loader.current = loadOnce(src, provider === 'enterprise' ? 'rc-enterprise' : 'rc-classic')
+        .then(() => {
+          const g = (window as W).grecaptcha;
+          const api = provider === 'enterprise' ? g?.enterprise : g;
+          if (!api) throw new Error('grecaptcha API missing on window');
+          api.ready(() => setReady(true));
+        })
+        .catch((e) => setError(e instanceof Error ? e.message : String(e)));
+    }
+  }, [siteKey, provider]);
+
+  const execute = async (action: string) => {
+    if (!siteKey) throw new Error('Missing reCAPTCHA site key');
+    if (!loader.current) throw new Error('reCAPTCHA not initialized');
+    await loader.current;
+    const g = (window as W).grecaptcha;
+    const api = provider === 'enterprise' ? g?.enterprise : g;
+    if (!api?.execute) throw new Error('reCAPTCHA not ready');
+    return api.execute(siteKey, { action });
+  };
+
+  return { ready, execute, error };
+}
+
+export async function prefetchToken(siteKey: string, provider: RecaptchaProvider, action = 'prefetch') {
+  const g = (window as W).grecaptcha;
+  const api = provider === 'enterprise' ? g?.enterprise : g;
+  if (!api?.execute) return;
+  try { await api.execute(siteKey, { action }); } catch {/* best effort */}
+}
+
+


### PR DESCRIPTION
- **Enhance frontend Dockerfile and Cloud Run deployment with reCAPTCHA environment variables**
- **feat(frontend): reCAPTCHA hook + global preloader; preload tokens on chat/voice; update feedback/settings to use hook and disable until ready; move badge per guidelines**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Google reCAPTCHA v3 into chat, feedback, settings, and voice pages for enhanced security.
  * Added support for both "classic" and "enterprise" reCAPTCHA providers, dynamically selected based on environment.
  * Introduced a reCAPTCHA preloader component to optimize token fetching across the app.

* **Improvements**
  * Feedback and settings buttons are disabled until reCAPTCHA is ready, with updated visual disabled states.
  * reCAPTCHA badge repositioned to the bottom-left corner for better UI consistency.
  * Added localized loading messages during reCAPTCHA readiness checks on feedback and settings pages.

* **Bug Fixes**
  * Improved error handling and logging to prevent reCAPTCHA issues from disrupting user interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->