### PR TITLE
refactor: streamline ChatClient feedback submission by removing 'Skip note' button

### DIFF
--- a/frontend/app/[locale]/chat/__tests__/chat-client.test.tsx
+++ b/frontend/app/[locale]/chat/__tests__/chat-client.test.tsx
@@ -99,8 +99,8 @@ describe('ChatClient - Inline Feedback', () => {
     expect(noteInput).toBeInTheDocument()
     expect(noteInput).not.toBeDisabled()
 
-    // Verify "Skip note" button appears
-    expect(screen.getByText('Skip note')).toBeInTheDocument()
+    // Verify single Send button is present (no separate Skip button)
+    expect(screen.getAllByText('Send')[0]).toBeInTheDocument()
   })
 
   it('allows entering and sending feedback with note', async () => {
@@ -175,9 +175,9 @@ describe('ChatClient - Inline Feedback', () => {
     const thumbsUpButtons = screen.getAllByLabelText('Thumbs up')
     fireEvent.click(thumbsUpButtons[thumbsUpButtons.length - 1])
 
-    // Click skip note
-    const skipButton = await screen.findByText('Skip note')
-    fireEvent.click(skipButton)
+    // Click Send without entering a note
+    const sendButtons = await screen.findAllByText('Send')
+    fireEvent.click(sendButtons[0])
 
     // Verify feedback was sent without note
     await waitFor(() => {
@@ -219,9 +219,9 @@ describe('ChatClient - Inline Feedback', () => {
     const thumbsUpButtons = screen.getAllByLabelText('Thumbs up')
     fireEvent.click(thumbsUpButtons[thumbsUpButtons.length - 1])
 
-    // Skip note initially
-    const skipButton = await screen.findByText('Skip note')
-    fireEvent.click(skipButton)
+    // Send without note initially
+    const sendButtons = await screen.findAllByText('Send')
+    fireEvent.click(sendButtons[0])
 
     // Wait for thanks message
     await waitFor(() => {
@@ -258,9 +258,8 @@ describe('ChatClient - Inline Feedback', () => {
     const thumbsUpButtons = screen.getAllByLabelText('Thumbs up')
     fireEvent.click(thumbsUpButtons[thumbsUpButtons.length - 1])
 
-    // Verify Spanish UI elements
+    // Verify Spanish UI elements (single Send button, optional note)
     expect(await screen.findByPlaceholderText('Nota opcional…')).toBeInTheDocument()
-    expect(screen.getByText('Omitir nota')).toBeInTheDocument()
     expect(screen.getByText('Enviar')).toBeInTheDocument()
   })
 
@@ -330,8 +329,9 @@ describe('ChatClient - Inline Feedback', () => {
     const thumbsDownButtons = screen.getAllByLabelText('Thumbs down')
     fireEvent.click(thumbsDownButtons[thumbsDownButtons.length - 1])
 
-    const skipButton = await screen.findByText('Skip note')
-    fireEvent.click(skipButton)
+    // Click Send without entering a note to trigger error path
+    const sendButtons = await screen.findAllByText('Send')
+    fireEvent.click(sendButtons[0])
 
     // Verify error message appears
     await waitFor(() => {

--- a/frontend/app/[locale]/chat/chat-client.tsx
+++ b/frontend/app/[locale]/chat/chat-client.tsx
@@ -445,17 +445,7 @@ export function ChatClient({ locale }: { locale: string }) {
                                       {inlineFeedback[index]?.sending ? (locale==='es'?'Enviando…':'Sending…') : (locale==='es'?'Enviar':'Send')}
                                     </button>
                                   </div>
-                                  {!inlineFeedback[index]?.sending && (
-                                    <div className="text-right">
-                                      <button
-                                        type="button"
-                                        onClick={() => handleSkipNote(index)}
-                                        className="text-xs text-white/60 hover:text-[#9BF7EB] transition-colors"
-                                      >
-                                        {locale==='es' ? 'Omitir nota' : 'Skip note'}
-                                      </button>
-                                    </div>
-                                  )}
+                                  {/* Removed separate 'Skip note' button: single Send handles with/without note */}
                                 </div>
                               )}
                               {inlineFeedback[index]?.error && (

--- a/frontend/app/[locale]/support/support-client.tsx
+++ b/frontend/app/[locale]/support/support-client.tsx
@@ -4,6 +4,7 @@ import { useRouter, usePathname } from 'next/navigation'
 import Link from 'next/link'
 import { AppLayout } from '@/components/layout/AppLayout'
 import { GlassCard } from '@/components/layout/GlassCard'
+import { ImportantReminder } from '@/components/ui/ImportantReminder'
 
 interface SupportClientProps {
   locale: string
@@ -163,56 +164,45 @@ export function SupportClient({ locale, translations: t }: SupportClientProps) {
             </GlassCard>
 
             {/* Important Reminder */}
-            <div className="rounded-[24px] backdrop-blur-[12px] p-8 border border-red-500/30"
-              style={{
-                background: 'rgba(127, 29, 29, 0.1)',
-              }}
-            >
-              <h2 className="text-xl font-heading font-semibold text-red-400 mb-4">
-                {t.reminder.title}
-              </h2>
-              <p className="text-white leading-relaxed">
-                {t.reminder.text}
-              </p>
-            </div>
-          </div>
+            <ImportantReminder locale={locale} variant="default" />
 
-          {/* Footer */}
-          <footer className="mt-24 pt-8 border-t border-white/10">
-            <div className="flex flex-col items-center gap-4">
-              <nav aria-label="Footer navigation">
-                <ul className="flex gap-6 text-sm">
-                  <li>
-                    <Link
-                      href={`/${locale}/privacy`}
-                      className="text-white/45 hover:text-[#aefcf5] transition-colors"
-                    >
-                      {t.footer.privacy}
-                    </Link>
-                  </li>
-                  <li>
-                    <Link
-                      href={`/${locale}/support`}
-                      className="text-[#aefcf5] font-medium"
-                    >
-                      {t.footer.support}
-                    </Link>
-                  </li>
-                  <li>
-                    <Link
-                      href={`/${locale}/about`}
-                      className="text-white/45 hover:text-[#aefcf5] transition-colors"
-                    >
-                      {t.footer.about}
-                    </Link>
-                  </li>
-                </ul>
-              </nav>
-              <p className="text-xs text-white/45">
-                © 2025 re-frame.social
-              </p>
-            </div>
-          </footer>
+            {/* Footer */}
+            <footer className="mt-24 pt-8 border-t border-white/10">
+              <div className="flex flex-col items-center gap-4">
+                <nav aria-label="Footer navigation">
+                  <ul className="flex gap-6 text-sm">
+                    <li>
+                      <Link
+                        href={`/${locale}/privacy`}
+                        className="text-white/45 hover:text-[#aefcf5] transition-colors"
+                      >
+                        {t.footer.privacy}
+                      </Link>
+                    </li>
+                    <li>
+                      <Link
+                        href={`/${locale}/support`}
+                        className="text-[#aefcf5] font-medium"
+                      >
+                        {t.footer.support}
+                      </Link>
+                    </li>
+                    <li>
+                      <Link
+                        href={`/${locale}/about`}
+                        className="text-white/45 hover:text-[#aefcf5] transition-colors"
+                      >
+                        {t.footer.about}
+                      </Link>
+                    </li>
+                  </ul>
+                </nav>
+                <p className="text-xs text-white/45">
+                  © 2025 re-frame.social
+                </p>
+              </div>
+            </footer>
+          </div>
         </div>
       </div>
     </AppLayout>


### PR DESCRIPTION
- Removed the separate 'Skip note' button, simplifying the feedback submission process to a single 'Send' button that handles both cases.
- Updated related tests to reflect this change, ensuring the new flow is validated and functioning correctly.
- Enhanced UI clarity by consolidating feedback actions, improving overall user experience.

Files Modified:
- chat-client.tsx
- chat-client.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The "Important Reminder" section in the support page now uses a consistent, reusable component for improved appearance and layout.

* **Refactor**
  * Inline feedback in chat now uses a single "Send" button for submitting feedback, consolidating the previous "Send" and "Skip note" buttons into one for a simpler user experience.

* **Tests**
  * Updated tests to reflect the new feedback submission flow using the single "Send" button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->