### PR TITLE
fix/sse sanitize ui

### DIFF
--- a/frontend/app/[locale]/chat/__tests__/chat-client.test.tsx
+++ b/frontend/app/[locale]/chat/__tests__/chat-client.test.tsx
@@ -99,8 +99,8 @@ describe('ChatClient - Inline Feedback', () => {
     expect(noteInput).toBeInTheDocument()
     expect(noteInput).not.toBeDisabled()
 
-    // Verify "Skip note" button appears
-    expect(screen.getByText('Skip note')).toBeInTheDocument()
+    // Verify single Send button is present (no separate Skip button)
+    expect(screen.getAllByText('Send')[0]).toBeInTheDocument()
   })
 
   it('allows entering and sending feedback with note', async () => {
@@ -175,9 +175,9 @@ describe('ChatClient - Inline Feedback', () => {
     const thumbsUpButtons = screen.getAllByLabelText('Thumbs up')
     fireEvent.click(thumbsUpButtons[thumbsUpButtons.length - 1])
 
-    // Click skip note
-    const skipButton = await screen.findByText('Skip note')
-    fireEvent.click(skipButton)
+    // Click Send without entering a note
+    const sendButtons = await screen.findAllByText('Send')
+    fireEvent.click(sendButtons[0])
 
     // Verify feedback was sent without note
     await waitFor(() => {
@@ -219,9 +219,9 @@ describe('ChatClient - Inline Feedback', () => {
     const thumbsUpButtons = screen.getAllByLabelText('Thumbs up')
     fireEvent.click(thumbsUpButtons[thumbsUpButtons.length - 1])
 
-    // Skip note initially
-    const skipButton = await screen.findByText('Skip note')
-    fireEvent.click(skipButton)
+    // Send without note initially
+    const sendButtons = await screen.findAllByText('Send')
+    fireEvent.click(sendButtons[0])
 
     // Wait for thanks message
     await waitFor(() => {
@@ -258,9 +258,8 @@ describe('ChatClient - Inline Feedback', () => {
     const thumbsUpButtons = screen.getAllByLabelText('Thumbs up')
     fireEvent.click(thumbsUpButtons[thumbsUpButtons.length - 1])
 
-    // Verify Spanish UI elements
+    // Verify Spanish UI elements (single Send button, optional note)
     expect(await screen.findByPlaceholderText('Nota opcional…')).toBeInTheDocument()
-    expect(screen.getByText('Omitir nota')).toBeInTheDocument()
     expect(screen.getByText('Enviar')).toBeInTheDocument()
   })
 
@@ -330,8 +329,9 @@ describe('ChatClient - Inline Feedback', () => {
     const thumbsDownButtons = screen.getAllByLabelText('Thumbs down')
     fireEvent.click(thumbsDownButtons[thumbsDownButtons.length - 1])
 
-    const skipButton = await screen.findByText('Skip note')
-    fireEvent.click(skipButton)
+    // Click Send without entering a note to trigger error path
+    const sendButtons = await screen.findAllByText('Send')
+    fireEvent.click(sendButtons[0])
 
     // Verify error message appears
     await waitFor(() => {

--- a/frontend/app/[locale]/chat/chat-client.tsx
+++ b/frontend/app/[locale]/chat/chat-client.tsx
@@ -445,17 +445,7 @@ export function ChatClient({ locale }: { locale: string }) {
                                       {inlineFeedback[index]?.sending ? (locale==='es'?'Enviando…':'Sending…') : (locale==='es'?'Enviar':'Send')}
                                     </button>
                                   </div>
-                                  {!inlineFeedback[index]?.sending && (
-                                    <div className="text-right">
-                                      <button
-                                        type="button"
-                                        onClick={() => handleSkipNote(index)}
-                                        className="text-xs text-white/60 hover:text-[#9BF7EB] transition-colors"
-                                      >
-                                        {locale==='es' ? 'Omitir nota' : 'Skip note'}
-                                      </button>
-                                    </div>
-                                  )}
+                                  {/* Removed separate 'Skip note' button: single Send handles with/without note */}
                                 </div>
                               )}
                               {inlineFeedback[index]?.error && (

--- a/frontend/app/[locale]/chat/chat-client.tsx
+++ b/frontend/app/[locale]/chat/chat-client.tsx
@@ -153,7 +153,7 @@ export function ChatClient({ locale }: { locale: string }) {
         setMessages(prev => [...prev, {
           role: 'assistant',
           content: finalContent,
-          frameworks: ['CBT'] // Default framework
+          frameworks: ['Aura'] // Default framework
         }])
       }
       bufferRef.current = ''
@@ -249,12 +249,6 @@ export function ChatClient({ locale }: { locale: string }) {
       } 
     }))
     // Don't send immediately - wait for user to add note or skip
-  }
-
-  const handleSkipNote = async (index: number) => {
-    const fb = inlineFeedback[index]
-    if (!fb?.selected) return
-    await sendInlineFeedback(index, fb.selected === 'up', undefined)
   }
 
   const handleSendNote = async (index: number) => {

--- a/frontend/app/[locale]/chat/chat-client.tsx
+++ b/frontend/app/[locale]/chat/chat-client.tsx
@@ -27,8 +27,7 @@ interface Translations {
 }
 
 export function ChatClient({ locale }: { locale: string }) {
-  // Backend now sanitizes UI (<ui> extraction), so frontend no longer strips content.
-  function passthroughText(raw: string): string { return raw || '' }
+  // Backend now sanitizes UI (<ui> extraction); no frontend sanitization needed.
   const router = useRouter()
   const [messages, setMessages] = useState<Message[]>([])
   const [input, setInput] = useState('')
@@ -149,7 +148,7 @@ export function ChatClient({ locale }: { locale: string }) {
 
     // If the turn completed, flush everything we've accumulated
     if (didTurnComplete) {
-      const finalContent = passthroughText(localBuffer)
+      const finalContent = localBuffer
       if (finalContent) {
         setMessages(prev => [...prev, {
           role: 'assistant',

--- a/frontend/app/[locale]/chat/chat-client.tsx
+++ b/frontend/app/[locale]/chat/chat-client.tsx
@@ -27,6 +27,8 @@ interface Translations {
 }
 
 export function ChatClient({ locale }: { locale: string }) {
+  // Backend now sanitizes UI (<ui> extraction), so frontend no longer strips content.
+  function passthroughText(raw: string): string { return raw || '' }
   const router = useRouter()
   const [messages, setMessages] = useState<Message[]>([])
   const [input, setInput] = useState('')
@@ -147,7 +149,7 @@ export function ChatClient({ locale }: { locale: string }) {
 
     // If the turn completed, flush everything we've accumulated
     if (didTurnComplete) {
-      const finalContent = localBuffer
+      const finalContent = passthroughText(localBuffer)
       if (finalContent) {
         setMessages(prev => [...prev, {
           role: 'assistant',

--- a/frontend/app/[locale]/support/support-client.tsx
+++ b/frontend/app/[locale]/support/support-client.tsx
@@ -4,6 +4,7 @@ import { useRouter, usePathname } from 'next/navigation'
 import Link from 'next/link'
 import { AppLayout } from '@/components/layout/AppLayout'
 import { GlassCard } from '@/components/layout/GlassCard'
+import { ImportantReminder } from '@/components/ui/ImportantReminder'
 
 interface SupportClientProps {
   locale: string
@@ -163,56 +164,45 @@ export function SupportClient({ locale, translations: t }: SupportClientProps) {
             </GlassCard>
 
             {/* Important Reminder */}
-            <div className="rounded-[24px] backdrop-blur-[12px] p-8 border border-red-500/30"
-              style={{
-                background: 'rgba(127, 29, 29, 0.1)',
-              }}
-            >
-              <h2 className="text-xl font-heading font-semibold text-red-400 mb-4">
-                {t.reminder.title}
-              </h2>
-              <p className="text-white leading-relaxed">
-                {t.reminder.text}
-              </p>
-            </div>
-          </div>
+            <ImportantReminder locale={locale} variant="default" />
 
-          {/* Footer */}
-          <footer className="mt-24 pt-8 border-t border-white/10">
-            <div className="flex flex-col items-center gap-4">
-              <nav aria-label="Footer navigation">
-                <ul className="flex gap-6 text-sm">
-                  <li>
-                    <Link
-                      href={`/${locale}/privacy`}
-                      className="text-white/45 hover:text-[#aefcf5] transition-colors"
-                    >
-                      {t.footer.privacy}
-                    </Link>
-                  </li>
-                  <li>
-                    <Link
-                      href={`/${locale}/support`}
-                      className="text-[#aefcf5] font-medium"
-                    >
-                      {t.footer.support}
-                    </Link>
-                  </li>
-                  <li>
-                    <Link
-                      href={`/${locale}/about`}
-                      className="text-white/45 hover:text-[#aefcf5] transition-colors"
-                    >
-                      {t.footer.about}
-                    </Link>
-                  </li>
-                </ul>
-              </nav>
-              <p className="text-xs text-white/45">
-                © 2025 re-frame.social
-              </p>
-            </div>
-          </footer>
+            {/* Footer */}
+            <footer className="mt-24 pt-8 border-t border-white/10">
+              <div className="flex flex-col items-center gap-4">
+                <nav aria-label="Footer navigation">
+                  <ul className="flex gap-6 text-sm">
+                    <li>
+                      <Link
+                        href={`/${locale}/privacy`}
+                        className="text-white/45 hover:text-[#aefcf5] transition-colors"
+                      >
+                        {t.footer.privacy}
+                      </Link>
+                    </li>
+                    <li>
+                      <Link
+                        href={`/${locale}/support`}
+                        className="text-[#aefcf5] font-medium"
+                      >
+                        {t.footer.support}
+                      </Link>
+                    </li>
+                    <li>
+                      <Link
+                        href={`/${locale}/about`}
+                        className="text-white/45 hover:text-[#aefcf5] transition-colors"
+                      >
+                        {t.footer.about}
+                      </Link>
+                    </li>
+                  </ul>
+                </nav>
+                <p className="text-xs text-white/45">
+                  © 2025 re-frame.social
+                </p>
+              </div>
+            </footer>
+          </div>
         </div>
       </div>
     </AppLayout>


### PR DESCRIPTION
- **refactor: streamline ChatClient feedback submission by removing 'Skip note' button**
- **text SSE: buffer raw chunks and emit sanitized <ui> content at turn_complete via orchestrator._extract_ui; remove frontend sanitization safety net**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assistant messages now display the updated framework label "Aura" instead of "CBT".

* **Improvements**
  * All chat content is now sanitized on the server side, ensuring consistent and secure display of messages.
  * Inline feedback has been streamlined—feedback is now submitted solely via the "Send" button, and the "Skip note" option has been removed for a simpler user experience.

* **Bug Fixes**
  * Improved reliability of feedback submission tests by ensuring the correct "Send" button is selected in all scenarios, including multi-language support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->